### PR TITLE
Add User Agent header to Java store Request object

### DIFF
--- a/trust_stores_observatory/store_fetcher/java_fetcher.py
+++ b/trust_stores_observatory/store_fetcher/java_fetcher.py
@@ -93,7 +93,7 @@ class JavaTrustStoreFetcher(StoreFetcherInterface):
         request = Request(
             final_url,
             # Cookie set when 'Accept License Agreement' is selected
-            headers={'Cookie': 'oraclelicense=accept-securebackup-cookie'}
+            headers={'Cookie': 'oraclelicense=accept-securebackup-cookie', 'User-Agent': 'Mozilla/5.0'}
         )
         response = urlopen(request)
 


### PR DESCRIPTION
Java store is causing the tests to fail.. I want to see if including User Agent in the request header will get the test passing. 

Let's find out! 