### PR TITLE
Java fetcher fix

### DIFF
--- a/tests/test_store_fetcher.py
+++ b/tests/test_store_fetcher.py
@@ -125,5 +125,5 @@ class JavaTrustStoreFetcherTests(unittest.TestCase):
         store_fetcher = JavaTrustStoreFetcher()
         fetched_store = store_fetcher.fetch(certs_repo)
         self.assertTrue(fetched_store)
-        self.assertGreater(len(fetched_store.trusted_certificates), 100)
+        self.assertGreater(len(fetched_store.trusted_certificates), 95)
         self.assertGreater(len(fetched_store.blocked_certificates), 10)

--- a/trust_stores_observatory/store_fetcher/java_fetcher.py
+++ b/trust_stores_observatory/store_fetcher/java_fetcher.py
@@ -154,7 +154,6 @@ class JavaTrustStoreFetcher(StoreFetcherInterface):
         blacklisted_records = []
         for fingerprint in blacklisted_certs_content.split("\n")[1:]:
             fingerprint = fingerprint.replace("\r", "")
-            fingerprint = fingerprint.replace(".", "")
             if not fingerprint:
                 continue
             blacklisted_records.append(

--- a/trust_stores_observatory/store_fetcher/java_fetcher.py
+++ b/trust_stores_observatory/store_fetcher/java_fetcher.py
@@ -183,6 +183,6 @@ class JavaTrustStoreFetcher(StoreFetcherInterface):
             latest_download_page = download_page.read().decode('utf-8')
 
         # The final download link for the .tar.gz JRE package is in a script tag
-        jre_download_url = latest_download_page.split('linux-x64_bin.tar.gz"')[0].rsplit('download.oracle.com', 1)[1]
-        final_download_url = f'http://download.oracle.com{jre_download_url}linux-x64_bin.tar.gz'
+        jre_download_url = latest_download_page.split('linux-x64.tar.gz"')[0].rsplit('download.oracle.com', 1)[1]
+        final_download_url = f'http://download.oracle.com{jre_download_url}linux-x64.tar.gz'
         return final_download_url

--- a/trust_stores_observatory/store_fetcher/java_fetcher.py
+++ b/trust_stores_observatory/store_fetcher/java_fetcher.py
@@ -153,6 +153,8 @@ class JavaTrustStoreFetcher(StoreFetcherInterface):
         # The file only contains a list of SHA-256 fingerprints
         blacklisted_records = []
         for fingerprint in blacklisted_certs_content.split("\n")[1:]:
+            fingerprint = fingerprint.replace("\r", "")
+            fingerprint = fingerprint.replace(".", "")
             if not fingerprint:
                 continue
             blacklisted_records.append(


### PR DESCRIPTION
It seems they:
* removed "_bin" suffix from the name
* changed from unix to windows newline style in the blacklist (made it so that it will handle even if they switch back to unix
* decreased the number of certs to 96 - adjusted the test

Oopsie, this seems to be downloading JRE 8, as the download for JRE 11 is missing (commented out in the HTML of https://www.oracle.com//technetwork/java/javase/downloads/index.html ) :)