### PR TITLE
Removed a space byte after a certificate footer.

### DIFF
--- a/certificates/40f6af0346a99aa1cd1d555a4e9cce62c7f9634603ee406615833dc8c8d00367.pem
+++ b/certificates/40f6af0346a99aa1cd1d555a4e9cce62c7f9634603ee406615833dc8c8d00367.pem
@@ -19,4 +19,4 @@ GNYIAwlG7mDgfrbESQRRfXBgvKqy/3lyeqYdPV8q+Mri/Tm3R7nrft8EI6/6nAYH
 6ftjk4BAtcZsCjEozgyfz7MjNYBBjWzEN3uBL4ChQEKF6dk4jeihU80Bv2noWgby
 RQuQ+q7hv53yrlc8pa6yVvSLZUDp/TGBLPQ5Cdjua6e0ph0VpZj3AYHYhX3zUVxx
 iN66zB+Afko=
------END CERTIFICATE----- 
+-----END CERTIFICATE-----


### PR DESCRIPTION
The reason for this tiny modification comes from an OpenJDK bug; Java X509Factory throws a CertificateException when parsing certificates with whitespace after the header or footer. While this bug has been patched in OpenJDK 12, it is still present in the previous versions:
https://bugs.openjdk.java.net/browse/JDK-8208602

This is the only certificate causing this exception.

Thank you!